### PR TITLE
Open transparent PNG images by default on left-click

### DIFF
--- a/PngViewer/FloatingImage.cs
+++ b/PngViewer/FloatingImage.cs
@@ -35,8 +35,8 @@ namespace PngViewer
                 ShowInTaskbar = false,
                 TopMost = true,
                 StartPosition = FormStartPosition.CenterScreen,
-                BackColor = System.Drawing.Color.Fuchsia, // This will be made transparent
-                TransparencyKey = System.Drawing.Color.Fuchsia,
+                BackColor = System.Drawing.Color.Transparent,
+                TransparencyKey = System.Drawing.Color.Transparent,
                 AutoSize = true,
                 AutoSizeMode = AutoSizeMode.GrowAndShrink
             };
@@ -45,7 +45,7 @@ namespace PngViewer
             _pictureBox = new System.Windows.Forms.PictureBox
             {
                 SizeMode = PictureBoxSizeMode.AutoSize,
-                BackColor = System.Drawing.Color.Fuchsia,
+                BackColor = System.Drawing.Color.Transparent,
                 Dock = DockStyle.None,
                 Margin = new System.Windows.Forms.Padding(0)
             };

--- a/PngViewer/FloatingImage.cs
+++ b/PngViewer/FloatingImage.cs
@@ -35,9 +35,8 @@ namespace PngViewer
                 ShowInTaskbar = false,
                 TopMost = true,
                 StartPosition = FormStartPosition.CenterScreen,
-                // Use a very unlikely color to be in the image for transparency
-                BackColor = System.Drawing.Color.FromArgb(1, 2, 3),
-                TransparencyKey = System.Drawing.Color.FromArgb(1, 2, 3),
+                BackColor = System.Drawing.Color.Fuchsia,
+                TransparencyKey = System.Drawing.Color.Fuchsia,
                 AutoSize = true,
                 AutoSizeMode = AutoSizeMode.GrowAndShrink
             };
@@ -46,7 +45,7 @@ namespace PngViewer
             _pictureBox = new System.Windows.Forms.PictureBox
             {
                 SizeMode = PictureBoxSizeMode.AutoSize,
-                BackColor = System.Drawing.Color.FromArgb(1, 2, 3),
+                BackColor = System.Drawing.Color.Fuchsia,
                 Dock = DockStyle.None,
                 Margin = new System.Windows.Forms.Padding(0)
             };

--- a/PngViewer/FloatingImage.cs
+++ b/PngViewer/FloatingImage.cs
@@ -35,8 +35,9 @@ namespace PngViewer
                 ShowInTaskbar = false,
                 TopMost = true,
                 StartPosition = FormStartPosition.CenterScreen,
-                BackColor = System.Drawing.Color.Transparent,
-                TransparencyKey = System.Drawing.Color.Transparent,
+                // Use a very unlikely color to be in the image for transparency
+                BackColor = System.Drawing.Color.FromArgb(1, 2, 3),
+                TransparencyKey = System.Drawing.Color.FromArgb(1, 2, 3),
                 AutoSize = true,
                 AutoSizeMode = AutoSizeMode.GrowAndShrink
             };
@@ -45,7 +46,7 @@ namespace PngViewer
             _pictureBox = new System.Windows.Forms.PictureBox
             {
                 SizeMode = PictureBoxSizeMode.AutoSize,
-                BackColor = System.Drawing.Color.Transparent,
+                BackColor = System.Drawing.Color.FromArgb(1, 2, 3),
                 Dock = DockStyle.None,
                 Margin = new System.Windows.Forms.Padding(0)
             };

--- a/PngViewer/MainWindow.xaml.cs
+++ b/PngViewer/MainWindow.xaml.cs
@@ -481,10 +481,30 @@ namespace PngViewer
                 {
                     if (File.Exists(pngFile.FilePath))
                     {
-                        // Open the image in a new window
-                        var imageViewer = new ImageViewerWindow(pngFile.FilePath);
-                        imageViewer.Owner = this;
-                        imageViewer.Show();
+                        // Open as transparent image instead of standard viewer
+                        var floatingImage = new FloatingImage(pngFile.FilePath);
+                        _floatingImages.Add(floatingImage);
+                        
+                        // Register for disposal when the floating image closes
+                        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+                        timer.Tick += (s, args) =>
+                        {
+                            // Check if any floating images have been closed and remove them from the list
+                            for (int i = _floatingImages.Count - 1; i >= 0; i--)
+                            {
+                                if (_floatingImages[i].IsDisposed)
+                                {
+                                    _floatingImages.RemoveAt(i);
+                                }
+                            }
+                            
+                            // If all images are gone, stop the timer
+                            if (_floatingImages.Count == 0)
+                            {
+                                timer.Stop();
+                            }
+                        };
+                        timer.Start();
                     }
                     else
                     {

--- a/PngViewer/MainWindow.xaml.cs
+++ b/PngViewer/MainWindow.xaml.cs
@@ -600,15 +600,17 @@ namespace PngViewer
                 // Clear collections
                 _pngFiles.Clear();
                 
-                // Dispose any open floating images
-                foreach (var floatingImage in _floatingImages)
+                // Dispose any open floating images - make a copy to avoid modification during enumeration
+                List<FloatingImage> floatingImagesCopy = new List<FloatingImage>(_floatingImages);
+                foreach (var floatingImage in floatingImagesCopy)
                 {
                     floatingImage.Dispose();
                 }
                 _floatingImages.Clear();
                 
-                // Dispose any open transparent windows
-                foreach (var window in _transparentWindows)
+                // Dispose any open transparent windows - make a copy to avoid modification during enumeration
+                List<TransparentImageWindow> transparentWindowsCopy = new List<TransparentImageWindow>(_transparentWindows);
+                foreach (var window in transparentWindowsCopy)
                 {
                     window.Close();
                     window.Dispose();

--- a/PngViewer/MainWindow.xaml.cs
+++ b/PngViewer/MainWindow.xaml.cs
@@ -482,7 +482,7 @@ namespace PngViewer
                 {
                     if (File.Exists(pngFile.FilePath))
                     {
-                        // Use WPF-based TransparentImageWindow instead of Windows Forms based FloatingImage
+                        // Use TransparentImageWindow for the default click behavior
                         var transparentWindow = new TransparentImageWindow(pngFile.FilePath);
                         _transparentWindows.Add(transparentWindow);
                         
@@ -544,7 +544,7 @@ namespace PngViewer
             {
                 try
                 {
-                    // Use WPF-based TransparentImageWindow instead of Windows Forms-based FloatingImage
+                    // Use TransparentImageWindow for opening images
                     var transparentWindow = new TransparentImageWindow(_currentContextPngFile.FilePath);
                     _transparentWindows.Add(transparentWindow);
                     

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -26,11 +26,17 @@
         </ControlTemplate>
     </Window.Template>
     
-    <!-- The only element is the image itself - no other UI elements -->
-    <Image x:Name="mainImage" 
-           Stretch="None" 
-           Margin="0"
-           RenderOptions.BitmapScalingMode="HighQuality"
-           SnapsToDevicePixels="True" 
-           UseLayoutRounding="True"/>
+    <!-- Border to outline the image for better visibility -->
+    <Border x:Name="MainBorder" 
+            BorderThickness="0" 
+            BorderBrush="#50808080"
+            Background="Transparent">
+        <!-- The image itself with no other UI elements -->
+        <Image x:Name="mainImage" 
+               Stretch="None" 
+               Margin="0"
+               RenderOptions.BitmapScalingMode="HighQuality"
+               SnapsToDevicePixels="True" 
+               UseLayoutRounding="True"/>
+    </Border>
 </Window>

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -63,10 +63,10 @@ namespace PngViewer
             var exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
             SetWindowLong(hwnd, GWL_EXSTYLE, exStyle | WS_EX_TOOLWINDOW);
             
-            // Ensure window is transparent
-            this.WindowStyle = WindowStyle.None;
-            this.Background = Brushes.Transparent;
-            this.AllowsTransparency = true;
+            // NOTE: We don't need to set these properties here as they're already set in XAML
+            // this.WindowStyle = WindowStyle.None;
+            // this.Background = Brushes.Transparent;
+            // this.AllowsTransparency = true;
             
             // Use a timer to allow the window to fully render before removing borders
             DispatcherTimer timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(10) };


### PR DESCRIPTION
## Changes Made

1. Modified the `Image_MouseLeftButtonDown` method in `MainWindow.xaml.cs` to open PNG images as transparent windows by default (previously opened in the standard viewer)
2. Fixed issue with the `TransparentImageWindow` by removing redundant property settings in the code-behind that were already defined in XAML
3. Switched from using Windows Forms-based `FloatingImage` to the WPF-based `TransparentImageWindow` for better transparency support
4. Maintained right-click context menu functionality for both viewing options
5. Added proper cleanup of transparent window resources

## Benefits

- More intuitive interface for viewing transparent PNG images with left-click
- Fixed transparency-related exceptions
- Better display of transparent images using WPF's native transparency support 
- Maintained ability to view images in standard viewer through context menu

This PR addresses the feature request to open transparent images by left mouse button click instead of requiring a right-click and menu selection.