### PR TITLE
Change left click to open transparent image

### DIFF
--- a/PngViewer/MainWindow.xaml.cs
+++ b/PngViewer/MainWindow.xaml.cs
@@ -481,10 +481,30 @@ namespace PngViewer
                 {
                     if (File.Exists(pngFile.FilePath))
                     {
-                        // Open the image in a new window
-                        var imageViewer = new ImageViewerWindow(pngFile.FilePath);
-                        imageViewer.Owner = this;
-                        imageViewer.Show();
+                        // Create a pure floating image with transparency
+                        var floatingImage = new FloatingImage(pngFile.FilePath);
+                        _floatingImages.Add(floatingImage);
+                        
+                        // Register for disposal when the floating image closes
+                        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+                        timer.Tick += (s, args) =>
+                        {
+                            // Check if any floating images have been closed and remove them from the list
+                            for (int i = _floatingImages.Count - 1; i >= 0; i--)
+                            {
+                                if (_floatingImages[i].IsDisposed)
+                                {
+                                    _floatingImages.RemoveAt(i);
+                                }
+                            }
+                            
+                            // If all images are gone, stop the timer
+                            if (_floatingImages.Count == 0)
+                            {
+                                timer.Stop();
+                            }
+                        };
+                        timer.Start();
                     }
                     else
                     {


### PR DESCRIPTION
This PR changes the behavior of left-clicking thumbnails. Instead of opening the standard image viewer, it now opens the transparent floating image viewer, providing a more direct way to access the transparent view functionality.

## Changes
- Modified the `Image_MouseLeftButtonDown` event handler to create a transparent floating image instead of opening the standard image viewer
- No other code changes were made as per requirements

## Testing
- Left-clicking on thumbnails now opens the floating transparent image viewer
- Right-click context menu still works as expected with both options