### PR TITLE
Fix transparent PNG pink outline issue

### DIFF
--- a/PngViewer/MainWindow.xaml.cs
+++ b/PngViewer/MainWindow.xaml.cs
@@ -1,20 +1,19 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using Microsoft.Win32;
-using System.Windows.Forms;
-using System.ComponentModel;
 
 namespace PngViewer
 {
@@ -34,8 +33,8 @@ namespace PngViewer
         // Store the current selected thumbnail for context menu
         private PngFile _currentContextPngFile;
         
-        // Keep track of open floating images
-        private List<FloatingImage> _floatingImages = new List<FloatingImage>();
+        // Keep track of open transparent windows
+        private List<TransparentImageWindow> _transparentWindows = new List<TransparentImageWindow>();
         
         // Placeholder for failed thumbnails
         private static BitmapImage _placeholderImage;
@@ -130,6 +129,15 @@ namespace PngViewer
                 // Reduce cache size
                 _thumbnailCache.Trim(100);
                 GC.Collect();
+            }
+            
+            // Check for disposed transparent windows and remove them from the list
+            for (int i = _transparentWindows.Count - 1; i >= 0; i--)
+            {
+                if (_transparentWindows[i]._disposed)
+                {
+                    _transparentWindows.RemoveAt(i);
+                }
             }
         }
 
@@ -481,30 +489,22 @@ namespace PngViewer
                 {
                     if (File.Exists(pngFile.FilePath))
                     {
-                        // Create a pure floating image with transparency
-                        var floatingImage = new FloatingImage(pngFile.FilePath);
-                        _floatingImages.Add(floatingImage);
+                        // Create a pure transparent window with better transparency handling
+                        var transparentWindow = new TransparentImageWindow(pngFile.FilePath);
                         
-                        // Register for disposal when the floating image closes
-                        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-                        timer.Tick += (s, args) =>
+                        // Keep a strong reference to prevent garbage collection
+                        _transparentWindows.Add(transparentWindow);
+                        
+                        // Set up window closing event to help with cleanup
+                        transparentWindow.Closed += (s, args) =>
                         {
-                            // Check if any floating images have been closed and remove them from the list
-                            for (int i = _floatingImages.Count - 1; i >= 0; i--)
+                            if (s is TransparentImageWindow window)
                             {
-                                if (_floatingImages[i].IsDisposed)
-                                {
-                                    _floatingImages.RemoveAt(i);
-                                }
-                            }
-                            
-                            // If all images are gone, stop the timer
-                            if (_floatingImages.Count == 0)
-                            {
-                                timer.Stop();
+                                window.Dispose();
                             }
                         };
-                        timer.Start();
+                        
+                        transparentWindow.Show();
                     }
                     else
                     {
@@ -555,30 +555,22 @@ namespace PngViewer
             {
                 try
                 {
-                    // Create a pure floating image with transparency
-                    var floatingImage = new FloatingImage(_currentContextPngFile.FilePath);
-                    _floatingImages.Add(floatingImage);
+                    // Create a pure transparent window with better transparency handling
+                    var transparentWindow = new TransparentImageWindow(_currentContextPngFile.FilePath);
                     
-                    // Register for disposal when the floating image closes
-                    var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-                    timer.Tick += (s, args) =>
+                    // Keep a strong reference to prevent garbage collection
+                    _transparentWindows.Add(transparentWindow);
+                    
+                    // Set up window closing event to help with cleanup
+                    transparentWindow.Closed += (s, args) =>
                     {
-                        // Check if any floating images have been closed and remove them from the list
-                        for (int i = _floatingImages.Count - 1; i >= 0; i--)
+                        if (s is TransparentImageWindow window)
                         {
-                            if (_floatingImages[i].IsDisposed)
-                            {
-                                _floatingImages.RemoveAt(i);
-                            }
-                        }
-                        
-                        // If all images are gone, stop the timer
-                        if (_floatingImages.Count == 0)
-                        {
-                            timer.Stop();
+                            window.Dispose();
                         }
                     };
-                    timer.Start();
+                    
+                    transparentWindow.Show();
                 }
                 catch (Exception ex)
                 {
@@ -623,12 +615,12 @@ namespace PngViewer
                 // Clear collections
                 _pngFiles.Clear();
                 
-                // Dispose any open floating images
-                foreach (var floatingImage in _floatingImages)
+                // Dispose any open transparent windows
+                foreach (var window in _transparentWindows)
                 {
-                    floatingImage.Dispose();
+                    window.Dispose();
                 }
-                _floatingImages.Clear();
+                _transparentWindows.Clear();
             }
             
             _disposed = true;

--- a/PngViewer/MainWindow.xaml.cs
+++ b/PngViewer/MainWindow.xaml.cs
@@ -140,8 +140,23 @@ namespace PngViewer
             // Remove disposed windows from the list
             for (int i = _transparentWindows.Count - 1; i >= 0; i--)
             {
-                if (_transparentWindows[i].IsDisposed)
+                if (_transparentWindows[i].IsDisposed || 
+                    !_transparentWindows[i].IsLoaded || 
+                    !_transparentWindows[i].IsVisible)
                 {
+                    // If window is disposed, not loaded, or not visible
+                    try
+                    {
+                        if (!_transparentWindows[i].IsDisposed)
+                        {
+                            _transparentWindows[i].Dispose();
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore any exceptions during cleanup
+                    }
+                    
                     _transparentWindows.RemoveAt(i);
                 }
             }
@@ -506,11 +521,19 @@ namespace PngViewer
                         {
                             if (s is TransparentImageWindow window)
                             {
-                                window.Dispose();
+                                try
+                                {
+                                    window.Dispose();
+                                }
+                                catch
+                                {
+                                    // Ignore any exceptions during disposal
+                                }
                                 // Cleanup happens in the timer
                             }
                         };
                         
+                        // Show as a non-modal dialog to maintain Z-order
                         transparentWindow.Show();
                     }
                     else
@@ -573,11 +596,19 @@ namespace PngViewer
                     {
                         if (s is TransparentImageWindow window)
                         {
-                            window.Dispose();
+                            try
+                            {
+                                window.Dispose();
+                            }
+                            catch
+                            {
+                                // Ignore any exceptions during disposal
+                            }
                             // Cleanup happens in the timer
                         }
                     };
                     
+                    // Show as a non-modal dialog to maintain Z-order
                     transparentWindow.Show();
                 }
                 catch (Exception ex)
@@ -626,9 +657,16 @@ namespace PngViewer
                 // Dispose any open transparent windows
                 foreach (var window in _transparentWindows)
                 {
-                    if (!window.IsDisposed)
+                    try
                     {
-                        window.Dispose();
+                        if (!window.IsDisposed)
+                        {
+                            window.Dispose();
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore any exceptions during disposal
                     }
                 }
                 _transparentWindows.Clear();

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -33,6 +33,8 @@ namespace PngViewer
         [DllImport("user32.dll")]
         private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
         
+        public bool IsDisposed => _disposed;
+        
         public TransparentImageWindow(string imagePath)
         {
             InitializeComponent();

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -65,10 +65,8 @@ namespace PngViewer
             var exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
             SetWindowLong(hwnd, GWL_EXSTYLE, exStyle | WS_EX_TOOLWINDOW);
             
-            // Ensure window is transparent
-            this.WindowStyle = WindowStyle.None;
-            this.Background = Brushes.Transparent;
-            this.AllowsTransparency = true;
+            // NOTE: AllowsTransparency is already set in XAML and cannot be changed here
+            // The Background is also set to Transparent in XAML
             
             // Use a timer to allow the window to fully render before removing borders
             DispatcherTimer timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(10) };


### PR DESCRIPTION
## Changes
This PR fixes the issue with transparent PNGs having a pink outline by:

1. Replacing the Windows Forms `FloatingImage` implementation with the existing WPF `TransparentImageWindow`
2. Adding proper window tracking to prevent windows from disappearing randomly (strong references maintained)
3. Adding an `IsDisposed` property to `TransparentImageWindow` to properly track disposal state
4. Improved cleanup of closed windows through the memory monitor timer

The key improvement is using WPF's native transparency support instead of trying to make Windows Forms transparent with a magenta color key, which was causing the pink outline artifacts.

## Testing
- Verified that transparent PNGs now display without any pink outlines
- Verified that windows remain open and don't disappear unexpectedly
- Tested memory usage and cleanup