### PR TITLE
Add direct mouse wheel zoom functionality

### DIFF
--- a/PngViewer/ImageViewerWindow.xaml.cs
+++ b/PngViewer/ImageViewerWindow.xaml.cs
@@ -205,14 +205,13 @@ namespace PngViewer
 
         private void ScrollViewer_MouseWheel(object sender, MouseWheelEventArgs e)
         {
-            if (Keyboard.Modifiers == ModifierKeys.Control)
-            {
-                // Determine zoom direction based on wheel delta
-                double zoomChange = e.Delta > 0 ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP;
-                ZoomImage(_zoomFactor + zoomChange);
-                
-                e.Handled = true;
-            }
+            // Always zoom with the mouse wheel, no Ctrl key required
+            // Determine zoom direction based on wheel delta
+            double zoomChange = e.Delta > 0 ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP;
+            ZoomImage(_zoomFactor + zoomChange);
+            
+            // Mark as handled to prevent ScrollViewer's default scrolling behavior
+            e.Handled = true;
         }
 
         private void ScrollViewer_MouseMove(object sender, MouseEventArgs e)


### PR DESCRIPTION
This PR adds the ability to directly zoom in/out with the mouse wheel without needing to hold the Ctrl key.

Changes:
- Modified the ScrollViewer_MouseWheel method to apply zooming directly when using the mouse wheel
- Removed the Ctrl key modifier check
- Set e.Handled = true to prevent the default scrolling behavior

The user can now:
- Scroll the wheel up to zoom in
- Scroll the wheel down to zoom out

This makes zooming more intuitive and faster than before.