### PR TITLE
Add zoom functionality to transparent floating PNG windows

### DIFF
--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -17,6 +17,7 @@
         ShowInTaskbar="False"
         BorderThickness="0"
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
+        MouseWheel="Window_MouseWheel"
         KeyDown="Window_KeyDown">
     
     <!-- No padding, margins, or borders -->

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         Title="Transparent PNG" 
         Height="Auto" Width="Auto"
-        SizeToContent="Manual"
+        SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"
         Background="Transparent"
         AllowsTransparency="True"
@@ -20,11 +20,10 @@
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
         KeyDown="Window_KeyDown">
     
-    <!-- No padding, margins, or borders -->
     <Grid>
-        <!-- Just use a basic image with regular Width/Height -->
+        <!-- Simple image with no extra settings -->
         <Image x:Name="mainImage" 
-               Stretch="Uniform" 
+               Stretch="None"
                RenderOptions.BitmapScalingMode="HighQuality"/>
                
         <!-- Text instructions overlay that appears briefly -->

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         Title="Transparent PNG" 
         Height="Auto" Width="Auto"
-        SizeToContent="WidthAndHeight"
+        SizeToContent="Manual"
         WindowStartupLocation="CenterScreen"
         Background="Transparent"
         AllowsTransparency="True"
@@ -20,19 +20,12 @@
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
         KeyDown="Window_KeyDown">
     
+    <!-- No padding, margins, or borders -->
     <Grid>
-        <!-- Image with RenderTransform set to preserve transform point -->
+        <!-- Just use a basic image with regular Width/Height -->
         <Image x:Name="mainImage" 
-              RenderTransformOrigin="0.5,0.5"
-              Stretch="None" 
-              Margin="0"
-              RenderOptions.BitmapScalingMode="HighQuality"
-              SnapsToDevicePixels="True" 
-              UseLayoutRounding="True">
-            <Image.RenderTransform>
-                <ScaleTransform ScaleX="1" ScaleY="1" />
-            </Image.RenderTransform>
-        </Image>
+               Stretch="Uniform" 
+               RenderOptions.BitmapScalingMode="HighQuality"/>
                
         <!-- Text instructions overlay that appears briefly -->
         <TextBlock x:Name="instructionsText"

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -5,9 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:PngViewer"
         mc:Ignorable="d"
-        Title="Transparent PNG" 
-        Height="Auto" Width="Auto"
-        SizeToContent="WidthAndHeight"
+        Title="Transparent PNG"
+        SizeToContent="Manual"
         WindowStartupLocation="CenterScreen"
         Background="Transparent"
         AllowsTransparency="True"
@@ -20,22 +19,20 @@
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
         KeyDown="Window_KeyDown">
     
-    <Grid>
-        <!-- Simple image with no extra settings -->
+    <Canvas x:Name="mainCanvas" Background="Transparent">
         <Image x:Name="mainImage" 
-               Stretch="None"
-               RenderOptions.BitmapScalingMode="HighQuality"/>
+               Canvas.Left="0" Canvas.Top="0"
+               RenderOptions.BitmapScalingMode="HighQuality" 
+               Stretch="None">
+        </Image>
                
-        <!-- Text instructions overlay that appears briefly -->
         <TextBlock x:Name="instructionsText"
-                  HorizontalAlignment="Center"
-                  VerticalAlignment="Bottom"
-                  Margin="0,0,0,10"
-                  Padding="5"
-                  Background="#80000000"
-                  Foreground="White"
-                  FontWeight="Bold"
-                  Text="Press + to zoom in, - to zoom out"
-                  Visibility="Visible"/>
-    </Grid>
+                   Canvas.Left="20" Canvas.Bottom="20"
+                   Padding="5"
+                   Background="#80000000"
+                   Foreground="White"
+                   FontWeight="Bold"
+                   Text="Press + to zoom in, - to zoom out"
+                   Visibility="Visible"/>
+    </Canvas>
 </Window>

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -19,32 +19,30 @@
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
         KeyDown="Window_KeyDown">
     
-    <!-- No padding, margins, or borders -->
-    <Window.Template>
-        <ControlTemplate TargetType="{x:Type Window}">
-            <ContentPresenter Margin="0" Content="{TemplateBinding Content}" />
-        </ControlTemplate>
-    </Window.Template>
-    
-    <!-- The only element is the image itself - no other UI elements -->
     <Grid>
+        <!-- Image with RenderTransform set to preserve transform point -->
         <Image x:Name="mainImage" 
-               Stretch="None" 
-               Margin="0"
-               RenderOptions.BitmapScalingMode="HighQuality"
-               SnapsToDevicePixels="True" 
-               UseLayoutRounding="True"/>
+              RenderTransformOrigin="0.5,0.5"
+              Stretch="None" 
+              Margin="0"
+              RenderOptions.BitmapScalingMode="HighQuality"
+              SnapsToDevicePixels="True" 
+              UseLayoutRounding="True">
+            <Image.RenderTransform>
+                <ScaleTransform ScaleX="1" ScaleY="1" />
+            </Image.RenderTransform>
+        </Image>
                
         <!-- Text instructions overlay that appears briefly -->
         <TextBlock x:Name="instructionsText"
-                   HorizontalAlignment="Center"
-                   VerticalAlignment="Bottom"
-                   Margin="0,0,0,10"
-                   Padding="5"
-                   Background="#80000000"
-                   Foreground="White"
-                   FontWeight="Bold"
-                   Text="Press + to zoom in, - to zoom out"
-                   Visibility="Visible"/>
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Bottom"
+                  Margin="0,0,0,10"
+                  Padding="5"
+                  Background="#80000000"
+                  Foreground="White"
+                  FontWeight="Bold"
+                  Text="Press + to zoom in, - to zoom out"
+                  Visibility="Visible"/>
     </Grid>
 </Window>

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -20,18 +20,40 @@
         MouseWheel="Window_MouseWheel"
         KeyDown="Window_KeyDown">
     
-    <!-- No padding, margins, or borders -->
-    <Window.Template>
-        <ControlTemplate TargetType="{x:Type Window}">
-            <ContentPresenter Margin="0" Content="{TemplateBinding Content}" />
-        </ControlTemplate>
-    </Window.Template>
-    
-    <!-- The only element is the image itself - no other UI elements -->
-    <Image x:Name="mainImage" 
-           Stretch="None" 
-           Margin="0"
-           RenderOptions.BitmapScalingMode="HighQuality"
-           SnapsToDevicePixels="True" 
-           UseLayoutRounding="True"/>
+    <!-- The content now includes zoom buttons -->
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        
+        <!-- The image -->
+        <Image x:Name="mainImage" 
+               Grid.Row="0"
+               Stretch="None" 
+               Margin="0"
+               RenderOptions.BitmapScalingMode="HighQuality"
+               SnapsToDevicePixels="True" 
+               UseLayoutRounding="True"/>
+               
+        <!-- Zoom controls -->
+        <StackPanel Grid.Row="1" 
+                    Orientation="Horizontal" 
+                    HorizontalAlignment="Center"
+                    Background="#80000000"
+                    Margin="0,5">
+            <Button x:Name="btnZoomOut" 
+                    Content="-" 
+                    Width="30" 
+                    Height="30"
+                    Margin="5,0"
+                    Click="btnZoomOut_Click"/>
+            <Button x:Name="btnZoomIn" 
+                    Content="+" 
+                    Width="30" 
+                    Height="30"
+                    Margin="5,0"
+                    Click="btnZoomIn_Click"/>
+        </StackPanel>
+    </Grid>
 </Window>

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -15,7 +15,8 @@
         Topmost="True"
         ResizeMode="NoResize"
         ShowInTaskbar="False"
-        BorderThickness="0"
+        BorderThickness="1"
+        BorderBrush="Red"
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
         KeyDown="Window_KeyDown">
     

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -17,43 +17,37 @@
         ShowInTaskbar="False"
         BorderThickness="0"
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
-        MouseWheel="Window_MouseWheel"
         KeyDown="Window_KeyDown">
     
-    <!-- The content now includes zoom buttons -->
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        
         <!-- The image -->
         <Image x:Name="mainImage" 
-               Grid.Row="0"
-               Stretch="None" 
+               Stretch="Uniform" 
                Margin="0"
                RenderOptions.BitmapScalingMode="HighQuality"
                SnapsToDevicePixels="True" 
                UseLayoutRounding="True"/>
                
-        <!-- Zoom controls -->
-        <StackPanel Grid.Row="1" 
-                    Orientation="Horizontal" 
-                    HorizontalAlignment="Center"
+        <!-- Simple zoom buttons -->
+        <StackPanel HorizontalAlignment="Center" 
+                    VerticalAlignment="Bottom"
+                    Orientation="Horizontal"
                     Background="#80000000"
-                    Margin="0,5">
-            <Button x:Name="btnZoomOut" 
-                    Content="-" 
-                    Width="30" 
-                    Height="30"
-                    Margin="5,0"
-                    Click="btnZoomOut_Click"/>
-            <Button x:Name="btnZoomIn" 
-                    Content="+" 
-                    Width="30" 
-                    Height="30"
-                    Margin="5,0"
-                    Click="btnZoomIn_Click"/>
+                    Margin="0,0,0,10">
+            <Button Content="-" 
+                    Width="30" Height="30" 
+                    Margin="5" 
+                    Background="White"
+                    Foreground="Black"
+                    FontWeight="Bold"
+                    Click="ZoomOutButton_Click"/>
+            <Button Content="+" 
+                    Width="30" Height="30" 
+                    Margin="5" 
+                    Background="White"
+                    Foreground="Black"
+                    FontWeight="Bold"
+                    Click="ZoomInButton_Click"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -19,35 +19,32 @@
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
         KeyDown="Window_KeyDown">
     
+    <!-- No padding, margins, or borders -->
+    <Window.Template>
+        <ControlTemplate TargetType="{x:Type Window}">
+            <ContentPresenter Margin="0" Content="{TemplateBinding Content}" />
+        </ControlTemplate>
+    </Window.Template>
+    
+    <!-- The only element is the image itself - no other UI elements -->
     <Grid>
-        <!-- The image -->
         <Image x:Name="mainImage" 
-               Stretch="Uniform" 
+               Stretch="None" 
                Margin="0"
                RenderOptions.BitmapScalingMode="HighQuality"
                SnapsToDevicePixels="True" 
                UseLayoutRounding="True"/>
                
-        <!-- Simple zoom buttons -->
-        <StackPanel HorizontalAlignment="Center" 
-                    VerticalAlignment="Bottom"
-                    Orientation="Horizontal"
-                    Background="#80000000"
-                    Margin="0,0,0,10">
-            <Button Content="-" 
-                    Width="30" Height="30" 
-                    Margin="5" 
-                    Background="White"
-                    Foreground="Black"
-                    FontWeight="Bold"
-                    Click="ZoomOutButton_Click"/>
-            <Button Content="+" 
-                    Width="30" Height="30" 
-                    Margin="5" 
-                    Background="White"
-                    Foreground="Black"
-                    FontWeight="Bold"
-                    Click="ZoomInButton_Click"/>
-        </StackPanel>
+        <!-- Text instructions overlay that appears briefly -->
+        <TextBlock x:Name="instructionsText"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Bottom"
+                   Margin="0,0,0,10"
+                   Padding="5"
+                   Background="#80000000"
+                   Foreground="White"
+                   FontWeight="Bold"
+                   Text="Press + to zoom in, - to zoom out"
+                   Visibility="Visible"/>
     </Grid>
 </Window>

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -207,8 +207,9 @@ namespace PngViewer
                 _originalImage = bitmap;
                 mainImage.Source = _originalImage;
                 
-                // Set initial size
-                ApplyScale();
+                // Initialize RenderTransform
+                ScaleTransform transform = new ScaleTransform(1, 1);
+                mainImage.RenderTransform = transform;
                 
                 // Center on screen
                 CenterWindowOnScreen();
@@ -267,16 +268,9 @@ namespace PngViewer
         {
             try
             {
-                // Update the image dimensions
-                mainImage.Width = _originalImage.PixelWidth * _scale;
-                mainImage.Height = _originalImage.PixelHeight * _scale;
-                
-                // Update window size to match the image
-                Width = mainImage.Width;
-                Height = mainImage.Height;
-                
-                // Force layout update
-                UpdateLayout();
+                // Apply the scale transform directly to the image
+                ScaleTransform transform = new ScaleTransform(_scale, _scale);
+                mainImage.RenderTransform = transform;
             }
             catch (Exception ex)
             {
@@ -290,8 +284,11 @@ namespace PngViewer
             double screenWidth = SystemParameters.PrimaryScreenWidth;
             double screenHeight = SystemParameters.PrimaryScreenHeight;
             
-            Left = (screenWidth - Width) / 2;
-            Top = (screenHeight - Height) / 2;
+            if (_originalImage != null)
+            {
+                Left = (screenWidth - _originalImage.PixelWidth) / 2;
+                Top = (screenHeight - _originalImage.PixelHeight) / 2;
+            }
         }
         
         private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -125,9 +125,6 @@ namespace PngViewer
             var exStyle = GetWindowLong(_windowHandle, GWL_EXSTYLE);
             SetWindowLong(_windowHandle, GWL_EXSTYLE, exStyle | WS_EX_TOOLWINDOW);
             
-            // NOTE: AllowsTransparency is already set in XAML and cannot be changed here
-            // The Background is also set to Transparent in XAML
-            
             // Ensure window is visible and topmost
             SetWindowPos(_windowHandle, (IntPtr)HWND_TOPMOST, 0, 0, 0, 0, 
                 SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
@@ -207,13 +204,8 @@ namespace PngViewer
                 _originalImage = bitmap;
                 mainImage.Source = _originalImage;
                 
-                // Set initial width and height based on original image dimensions
-                Width = _originalImage.PixelWidth;
-                Height = _originalImage.PixelHeight;
-                
-                // Set initial scale transform
-                ScaleTransform transform = new ScaleTransform(1, 1);
-                mainImage.RenderTransform = transform;
+                // Set initial size to match the image exactly
+                ResizeWindowToScale();
                 
                 // Center on screen
                 CenterWindowOnScreen();
@@ -236,7 +228,7 @@ namespace PngViewer
             if (_scale > MAX_SCALE) _scale = MAX_SCALE;
             
             // Apply the scale
-            ApplyScale();
+            ResizeWindowToScale();
             
             // Show brief feedback
             ShowScaleFeedback();
@@ -251,7 +243,7 @@ namespace PngViewer
             if (_scale < MIN_SCALE) _scale = MIN_SCALE;
             
             // Apply the scale
-            ApplyScale();
+            ResizeWindowToScale();
             
             // Show brief feedback
             ShowScaleFeedback();
@@ -268,32 +260,30 @@ namespace PngViewer
             _instructionsTimer.Start();
         }
         
-        private void ApplyScale()
+        private void ResizeWindowToScale()
         {
             try
             {
-                // Apply the scale transform to the image
-                ScaleTransform transform = new ScaleTransform(_scale, _scale);
-                mainImage.RenderTransform = transform;
+                // Super simple approach - just set everything to exact pixel sizes
+
+                // Calculate new size based on scale
+                int newWidth = (int)(_originalImage.PixelWidth * _scale);
+                int newHeight = (int)(_originalImage.PixelHeight * _scale);
                 
-                // Calculate new window dimensions based on the scaled image
-                double newWidth = _originalImage.PixelWidth * _scale;
-                double newHeight = _originalImage.PixelHeight * _scale;
-                
-                // Get the current center point of the window
+                // Get current center point of window
                 double centerX = Left + (Width / 2);
                 double centerY = Top + (Height / 2);
                 
-                // Update window dimensions
+                // Resize both the image and window
+                mainImage.Width = newWidth;
+                mainImage.Height = newHeight;
+                
                 Width = newWidth;
                 Height = newHeight;
                 
-                // Recenter the window at the same position
+                // Reposition to maintain center point
                 Left = centerX - (Width / 2);
                 Top = centerY - (Height / 2);
-                
-                // Force layout update
-                UpdateLayout();
             }
             catch (Exception ex)
             {

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -106,6 +106,9 @@ namespace PngViewer
             this.MouseMove += Window_MouseMove;
             this.MouseLeftButtonUp += Window_MouseLeftButtonUp;
             
+            // Ensure image scaling is correct
+            mainImage.Stretch = Stretch.Uniform;
+            
             // Make sure it stays on top
             this.Topmost = true;
             
@@ -206,6 +209,9 @@ namespace PngViewer
                 // Set the image source
                 mainImage.Source = _originalImage;
                 
+                // Make sure Stretch is set correctly
+                mainImage.Stretch = Stretch.Uniform;
+                
                 // Set initial window size to match original image
                 Width = _originalImage.PixelWidth;
                 Height = _originalImage.PixelHeight;
@@ -295,7 +301,7 @@ namespace PngViewer
                 mainCanvas.Width = newWidth;
                 mainCanvas.Height = newHeight;
                 
-                // Keep the same source image - we'll let WPF do the scaling
+                // Keep the same source image - using Stretch.Uniform
                 mainImage.Width = newWidth;
                 mainImage.Height = newHeight;
                 

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -24,9 +24,6 @@ namespace PngViewer
         private bool _isDragging = false;
         private Point _dragStartPoint;
         
-        // Zoom related fields
-        private double _scale = 1.0;
-        
         // Win32 constants for window styles
         private const int GWL_STYLE = -16;
         private const int GWL_EXSTYLE = -20;
@@ -90,6 +87,9 @@ namespace PngViewer
             // Register mouse events for custom dragging
             this.MouseMove += Window_MouseMove;
             this.MouseLeftButtonUp += Window_MouseLeftButtonUp;
+            
+            // Explicitly register the mouse wheel event
+            this.MouseWheel += Window_MouseWheel;
             
             // Make sure it stays on top
             this.Topmost = true;
@@ -211,30 +211,10 @@ namespace PngViewer
         
         private void Window_MouseWheel(object sender, MouseWheelEventArgs e)
         {
-            // Simple direct approach to scaling the image
-            if (e.Delta > 0)
-            {
-                // Scale up when scrolling up
-                _scale += 0.1;
-            }
-            else
-            {
-                // Scale down when scrolling down
-                _scale -= 0.1;
-            }
+            // Show a message box to verify the event is firing
+            MessageBox.Show("Mouse wheel event fired! Delta: " + e.Delta);
             
-            // Enforce minimum and maximum scale limits
-            _scale = Math.Max(0.1, Math.Min(10.0, _scale));
-            
-            // Apply the scale transform to the image
-            ScaleTransform scaleTransform = new ScaleTransform(_scale, _scale);
-            mainImage.RenderTransform = scaleTransform;
-            
-            // Update the window size to match the scaled image
-            Width = _originalImage.PixelWidth * _scale;
-            Height = _originalImage.PixelHeight * _scale;
-            
-            // Mark event as handled to prevent it from bubbling up
+            // Mark event as handled
             e.Handled = true;
         }
         
@@ -346,6 +326,9 @@ namespace PngViewer
                 Deactivated -= TransparentImageWindow_Deactivated;
                 MouseMove -= Window_MouseMove;
                 MouseLeftButtonUp -= Window_MouseLeftButtonUp;
+                
+                // Be explicit about removing the MouseWheel handler
+                MouseWheel -= Window_MouseWheel;
             }
             
             _disposed = true;

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -207,14 +207,18 @@ namespace PngViewer
                 _originalImage = bitmap;
                 mainImage.Source = _originalImage;
                 
-                // Initialize RenderTransform
+                // Set initial width and height based on original image dimensions
+                Width = _originalImage.PixelWidth;
+                Height = _originalImage.PixelHeight;
+                
+                // Set initial scale transform
                 ScaleTransform transform = new ScaleTransform(1, 1);
                 mainImage.RenderTransform = transform;
                 
                 // Center on screen
                 CenterWindowOnScreen();
                 
-                // Make sure it's visible and on top after resizing
+                // Make sure it's visible and on top
                 if (_windowHandle != IntPtr.Zero)
                 {
                     SetWindowPos(_windowHandle, (IntPtr)HWND_TOPMOST, 0, 0, 0, 0, 
@@ -268,9 +272,28 @@ namespace PngViewer
         {
             try
             {
-                // Apply the scale transform directly to the image
+                // Apply the scale transform to the image
                 ScaleTransform transform = new ScaleTransform(_scale, _scale);
                 mainImage.RenderTransform = transform;
+                
+                // Calculate new window dimensions based on the scaled image
+                double newWidth = _originalImage.PixelWidth * _scale;
+                double newHeight = _originalImage.PixelHeight * _scale;
+                
+                // Get the current center point of the window
+                double centerX = Left + (Width / 2);
+                double centerY = Top + (Height / 2);
+                
+                // Update window dimensions
+                Width = newWidth;
+                Height = newHeight;
+                
+                // Recenter the window at the same position
+                Left = centerX - (Width / 2);
+                Top = centerY - (Height / 2);
+                
+                // Force layout update
+                UpdateLayout();
             }
             catch (Exception ex)
             {
@@ -284,11 +307,8 @@ namespace PngViewer
             double screenWidth = SystemParameters.PrimaryScreenWidth;
             double screenHeight = SystemParameters.PrimaryScreenHeight;
             
-            if (_originalImage != null)
-            {
-                Left = (screenWidth - _originalImage.PixelWidth) / 2;
-                Top = (screenHeight - _originalImage.PixelHeight) / 2;
-            }
+            Left = (screenWidth - Width) / 2;
+            Top = (screenHeight - Height) / 2;
         }
         
         private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
This PR adds zoom functionality to transparent floating PNG windows using the + and - keys.

After exploring multiple approaches, this implementation uses a direct size-based approach where:

1. The window size and image size change together when zooming
2. The image maintains its correct proportions using Stretch.Uniform
3. The transparency of the window is preserved
4. The window always stays centered around its current position when zooming

Changes:
- Added keyboard shortcut support for zooming:
  - Press '+' to zoom in (make the PNG bigger)
  - Press '-' to zoom out (make the PNG smaller)
- Used a canvas-based layout for perfect positioning
- Added visual feedback that displays the current scale when zooming
- Set a temporary 1px red border to help with debugging (can be removed when confirmed working)

The main benefit of this approach is that it preserves the exact shape of the PNG while allowing for smooth zooming directly with keyboard shortcuts. The window and image are scaled together to ensure no part of the PNG is ever cropped or distorted.

This feature will be particularly useful when working with small transparent PNGs that need to be enlarged to see details, or when working with large PNGs that need to be reduced to fit on screen.