### PR TITLE
Add Mouse Wheel Zoom for Floating Transparent PNGs

### DIFF
--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -27,26 +27,16 @@
         </ControlTemplate>
     </Window.Template>
     
-    <Grid>
-        <!-- Border to show the outline when zoomed -->
-        <Border x:Name="boundingBoxBorder" 
-                BorderBrush="Red" 
-                BorderThickness="1.5" 
-                Visibility="Collapsed" 
-                HorizontalAlignment="Center" 
-                VerticalAlignment="Center" />
-                
-        <!-- The image element -->
-        <Image x:Name="mainImage" 
-               Stretch="None" 
-               Margin="0"
-               RenderOptions.BitmapScalingMode="HighQuality"
-               SnapsToDevicePixels="True" 
-               UseLayoutRounding="True"
-               RenderTransformOrigin="0.5,0.5">
-            <Image.RenderTransform>
-                <ScaleTransform x:Name="imageScale" ScaleX="1" ScaleY="1" />
-            </Image.RenderTransform>
-        </Image>
-    </Grid>
+    <!-- The image element -->
+    <Image x:Name="mainImage" 
+           Stretch="None" 
+           Margin="0"
+           RenderOptions.BitmapScalingMode="HighQuality"
+           SnapsToDevicePixels="True" 
+           UseLayoutRounding="True"
+           RenderTransformOrigin="0.5,0.5">
+        <Image.RenderTransform>
+            <ScaleTransform x:Name="imageScale" ScaleX="1" ScaleY="1" />
+        </Image.RenderTransform>
+    </Image>
 </Window>

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -27,16 +27,26 @@
         </ControlTemplate>
     </Window.Template>
     
-    <!-- The only element is the image itself - no other UI elements -->
-    <Image x:Name="mainImage" 
-           Stretch="None" 
-           Margin="0"
-           RenderOptions.BitmapScalingMode="HighQuality"
-           SnapsToDevicePixels="True" 
-           UseLayoutRounding="True"
-           RenderTransformOrigin="0.5,0.5">
-        <Image.RenderTransform>
-            <ScaleTransform x:Name="imageScale" ScaleX="1" ScaleY="1" />
-        </Image.RenderTransform>
-    </Image>
+    <Grid>
+        <!-- Border to show the outline when zoomed -->
+        <Border x:Name="boundingBoxBorder" 
+                BorderBrush="Red" 
+                BorderThickness="1.5" 
+                Visibility="Collapsed" 
+                HorizontalAlignment="Center" 
+                VerticalAlignment="Center" />
+                
+        <!-- The image element -->
+        <Image x:Name="mainImage" 
+               Stretch="None" 
+               Margin="0"
+               RenderOptions.BitmapScalingMode="HighQuality"
+               SnapsToDevicePixels="True" 
+               UseLayoutRounding="True"
+               RenderTransformOrigin="0.5,0.5">
+            <Image.RenderTransform>
+                <ScaleTransform x:Name="imageScale" ScaleX="1" ScaleY="1" />
+            </Image.RenderTransform>
+        </Image>
+    </Grid>
 </Window>

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -17,8 +17,7 @@
         ShowInTaskbar="False"
         BorderThickness="0"
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
-        KeyDown="Window_KeyDown"
-        MouseWheel="Window_MouseWheel">
+        KeyDown="Window_KeyDown">
     
     <!-- No padding, margins, or borders -->
     <Window.Template>

--- a/PngViewer/TransparentImageWindow.xaml
+++ b/PngViewer/TransparentImageWindow.xaml
@@ -17,7 +17,8 @@
         ShowInTaskbar="False"
         BorderThickness="0"
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
-        KeyDown="Window_KeyDown">
+        KeyDown="Window_KeyDown"
+        MouseWheel="Window_MouseWheel">
     
     <!-- No padding, margins, or borders -->
     <Window.Template>
@@ -32,5 +33,10 @@
            Margin="0"
            RenderOptions.BitmapScalingMode="HighQuality"
            SnapsToDevicePixels="True" 
-           UseLayoutRounding="True"/>
+           UseLayoutRounding="True"
+           RenderTransformOrigin="0.5,0.5">
+        <Image.RenderTransform>
+            <ScaleTransform x:Name="imageScale" ScaleX="1" ScaleY="1" />
+        </Image.RenderTransform>
+    </Image>
 </Window>

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -200,6 +200,10 @@ namespace PngViewer
                 Width = _originalImage.PixelWidth;
                 Height = _originalImage.PixelHeight;
                 
+                // Set the border size to match the image dimensions
+                boundingBoxBorder.Width = _originalImage.PixelWidth;
+                boundingBoxBorder.Height = _originalImage.PixelHeight;
+                
                 // Ensure window is centered on screen
                 CenterWindowOnScreen();
                 
@@ -287,9 +291,23 @@ namespace PngViewer
                 imageScale.ScaleX = _currentZoom;
                 imageScale.ScaleY = _currentZoom;
                 
-                // We intentionally do not resize the window - the transform handles the scaling
+                // Show the bounding box if zoomed
+                UpdateBoundingBoxVisibility();
                 
                 e.Handled = true;
+            }
+        }
+        
+        private void UpdateBoundingBoxVisibility()
+        {
+            // Show the bounding box only when zoomed in or out from 100%
+            if (Math.Abs(_currentZoom - 1.0) > 0.001)
+            {
+                boundingBoxBorder.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                boundingBoxBorder.Visibility = Visibility.Collapsed;
             }
         }
         
@@ -305,6 +323,23 @@ namespace PngViewer
             {
                 ResetZoom();
             }
+            // Toggle bounding box on 'B' key
+            else if (e.Key == Key.B)
+            {
+                ToggleBoundingBox();
+            }
+        }
+        
+        private void ToggleBoundingBox()
+        {
+            if (boundingBoxBorder.Visibility == Visibility.Visible)
+            {
+                boundingBoxBorder.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                boundingBoxBorder.Visibility = Visibility.Visible;
+            }
         }
         
         private void ResetZoom()
@@ -312,6 +347,9 @@ namespace PngViewer
             _currentZoom = 1.0;
             imageScale.ScaleX = 1.0;
             imageScale.ScaleY = 1.0;
+            
+            // Hide the bounding box at default zoom
+            boundingBoxBorder.Visibility = Visibility.Collapsed;
         }
         
         protected override void OnClosing(CancelEventArgs e)

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -1,24 +1,25 @@
 using System;
 using System.IO;
 using System.Windows;
-using System.Windows.Input;
-using System.Windows.Media.Imaging;
-using System.Threading.Tasks;
-using System.ComponentModel;
-using System.Windows.Interop;
-using System.Runtime.InteropServices;
-using System.Windows.Media;
 using System.Windows.Threading;
-using System.Windows.Forms;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
+
+// Use aliases to avoid ambiguity
+using WinForms = System.Windows.Forms;
+using WinInput = System.Windows.Input;
+using WinInterop = System.Windows.Interop;
+using WinMedia = System.Windows.Media;
+using WinImaging = System.Windows.Media.Imaging;
 
 namespace PngViewer
 {
     public partial class TransparentImageWindow : Window, IDisposable
     {
         private string _imagePath;
-        private BitmapSource _originalImage;
+        private WinImaging.BitmapSource _originalImage;
         private bool _disposed = false;
         private readonly BackgroundWorker _imageLoader = new BackgroundWorker();
         private readonly DispatcherTimer _visibilityTimer;
@@ -117,7 +118,7 @@ namespace PngViewer
 
         private void TransparentImageWindow_Loaded(object sender, RoutedEventArgs e)
         {
-            _windowHandle = new WindowInteropHelper(this).Handle;
+            _windowHandle = new WinInterop.WindowInteropHelper(this).Handle;
             
             // Remove system menu, caption and borders
             var style = GetWindowLong(_windowHandle, GWL_STYLE);
@@ -141,14 +142,14 @@ namespace PngViewer
         private void CreateCaptureWindow()
         {
             // Find the screen our window is on
-            var currentScreen = Screen.FromHandle(_windowHandle);
+            var currentScreen = WinForms.Screen.FromHandle(_windowHandle);
             
             // Create an invisible window that covers the entire screen's working area
             _captureWindow = new Window
             {
                 WindowStyle = WindowStyle.None,
                 AllowsTransparency = true,
-                Background = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0)), // Nearly transparent
+                Background = new WinMedia.SolidColorBrush(WinMedia.Color.FromArgb(1, 0, 0, 0)), // Nearly transparent
                 Topmost = true,
                 ResizeMode = ResizeMode.NoResize,
                 ShowInTaskbar = false,
@@ -180,7 +181,7 @@ namespace PngViewer
             _captureWindow.Show();
             
             // Further customize it with Win32 API calls
-            var hwnd = new WindowInteropHelper(_captureWindow).Handle;
+            var hwnd = new WinInterop.WindowInteropHelper(_captureWindow).Handle;
             
             // Make it a tool window that doesn't appear in Alt+Tab
             var exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
@@ -231,11 +232,11 @@ namespace PngViewer
             string filePath = e.Argument as string;
             try
             {
-                var bitmap = new BitmapImage();
+                var bitmap = new WinImaging.BitmapImage();
                 bitmap.BeginInit();
                 bitmap.UriSource = new Uri(filePath);
-                bitmap.CacheOption = BitmapCacheOption.OnLoad;
-                bitmap.CreateOptions = BitmapCreateOptions.IgnoreColorProfile | BitmapCreateOptions.PreservePixelFormat;
+                bitmap.CacheOption = WinImaging.BitmapCacheOption.OnLoad;
+                bitmap.CreateOptions = WinImaging.BitmapCreateOptions.IgnoreColorProfile | WinImaging.BitmapCreateOptions.PreservePixelFormat;
                 bitmap.EndInit();
                 bitmap.Freeze();
                 
@@ -257,7 +258,7 @@ namespace PngViewer
                 return;
             }
             
-            if (e.Result is BitmapSource bitmap)
+            if (e.Result is WinImaging.BitmapSource bitmap)
             {
                 _originalImage = bitmap;
                 mainImage.Source = _originalImage;
@@ -294,7 +295,7 @@ namespace PngViewer
             }
         }
         
-        private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        private void Window_MouseLeftButtonDown(object sender, WinInput.MouseButtonEventArgs e)
         {
             // Start the custom dragging operation
             _isDragging = true;
@@ -307,7 +308,7 @@ namespace PngViewer
             e.Handled = true;
         }
         
-        private void Window_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+        private void Window_MouseMove(object sender, WinInput.MouseEventArgs e)
         {
             if (_isDragging)
             {
@@ -338,7 +339,7 @@ namespace PngViewer
             if (_captureWindow != null)
             {
                 // Find the screen our window is now on
-                var currentScreen = Screen.FromHandle(_windowHandle);
+                var currentScreen = WinForms.Screen.FromHandle(_windowHandle);
                 
                 // Update the capture window to match the current screen
                 _captureWindow.Width = currentScreen.WorkingArea.Width;
@@ -348,7 +349,7 @@ namespace PngViewer
             }
         }
         
-        private void Window_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        private void Window_MouseLeftButtonUp(object sender, WinInput.MouseButtonEventArgs e)
         {
             if (_isDragging)
             {
@@ -357,7 +358,7 @@ namespace PngViewer
             }
         }
         
-        private void Window_MouseWheel(object sender, System.Windows.Input.MouseWheelEventArgs e)
+        private void Window_MouseWheel(object sender, WinInput.MouseWheelEventArgs e)
         {
             // Calculate new zoom factor based on wheel direction
             double zoomChange = e.Delta > 0 ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP;
@@ -379,15 +380,15 @@ namespace PngViewer
             }
         }
         
-        private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        private void Window_KeyDown(object sender, WinInput.KeyEventArgs e)
         {
             // Close window on Escape or Space
-            if (e.Key == Key.Escape || e.Key == Key.Space)
+            if (e.Key == WinInput.Key.Escape || e.Key == WinInput.Key.Space)
             {
                 Close();
             }
             // Reset zoom on 'R' key
-            else if (e.Key == Key.R)
+            else if (e.Key == WinInput.Key.R)
             {
                 ResetZoom();
             }
@@ -462,7 +463,7 @@ namespace PngViewer
             _disposed = true;
         }
         
-        private void ReleaseImage(ref BitmapSource image)
+        private void ReleaseImage(ref WinImaging.BitmapSource image)
         {
             if (image != null)
             {
@@ -474,7 +475,7 @@ namespace PngViewer
     
     public class ScreenInfo
     {
-        public System.Windows.Forms.Screen Screen { get; set; }
+        public WinForms.Screen Screen { get; set; }
         public Rect Bounds { get; set; }
         public Rect WorkingArea { get; set; }
         public bool IsPrimary { get; set; }

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -24,6 +24,12 @@ namespace PngViewer
         private bool _isDragging = false;
         private Point _dragStartPoint;
         
+        // Zoom related constants and fields
+        private const double ZOOM_FACTOR_STEP = 0.1;
+        private const double MIN_ZOOM = 0.1;
+        private const double MAX_ZOOM = 10.0;
+        private double _currentZoom = 1.0;
+        
         // Win32 constants for window styles
         private const int GWL_STYLE = -16;
         private const int GWL_EXSTYLE = -20;
@@ -263,6 +269,30 @@ namespace PngViewer
             }
         }
         
+        private void Window_MouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            // Calculate new zoom factor based on wheel direction
+            double zoomChange = e.Delta > 0 ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP;
+            double newZoom = _currentZoom + zoomChange;
+            
+            // Enforce min/max zoom limits
+            newZoom = Math.Max(MIN_ZOOM, Math.Min(MAX_ZOOM, newZoom));
+            
+            // Only update if the zoom actually changed
+            if (Math.Abs(_currentZoom - newZoom) > 0.001)
+            {
+                _currentZoom = newZoom;
+                
+                // Apply the new zoom factor to the ScaleTransform
+                imageScale.ScaleX = _currentZoom;
+                imageScale.ScaleY = _currentZoom;
+                
+                // We intentionally do not resize the window - the transform handles the scaling
+                
+                e.Handled = true;
+            }
+        }
+        
         private void Window_KeyDown(object sender, KeyEventArgs e)
         {
             // Close window on Escape or Space
@@ -270,6 +300,18 @@ namespace PngViewer
             {
                 Close();
             }
+            // Reset zoom on 'R' key
+            else if (e.Key == Key.R)
+            {
+                ResetZoom();
+            }
+        }
+        
+        private void ResetZoom()
+        {
+            _currentZoom = 1.0;
+            imageScale.ScaleX = 1.0;
+            imageScale.ScaleY = 1.0;
         }
         
         protected override void OnClosing(CancelEventArgs e)

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -307,7 +307,7 @@ namespace PngViewer
             e.Handled = true;
         }
         
-        private void Window_MouseMove(object sender, MouseEventArgs e)
+        private void Window_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
         {
             if (_isDragging)
             {
@@ -357,7 +357,7 @@ namespace PngViewer
             }
         }
         
-        private void Window_MouseWheel(object sender, MouseWheelEventArgs e)
+        private void Window_MouseWheel(object sender, System.Windows.Input.MouseWheelEventArgs e)
         {
             // Calculate new zoom factor based on wheel direction
             double zoomChange = e.Delta > 0 ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP;
@@ -379,7 +379,7 @@ namespace PngViewer
             }
         }
         
-        private void Window_KeyDown(object sender, KeyEventArgs e)
+        private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
             // Close window on Escape or Space
             if (e.Key == Key.Escape || e.Key == Key.Space)
@@ -470,5 +470,13 @@ namespace PngViewer
                 image = null;
             }
         }
+    }
+    
+    public class ScreenInfo
+    {
+        public System.Windows.Forms.Screen Screen { get; set; }
+        public Rect Bounds { get; set; }
+        public Rect WorkingArea { get; set; }
+        public bool IsPrimary { get; set; }
     }
 }

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -180,27 +180,7 @@ namespace PngViewer
             _fullscreenWindow.IsHitTestVisible = true; // We need this to capture mouse wheel events
             
             // Wire up mouse wheel event to be forwarded to our window
-            _fullscreenWindow.MouseWheel += (s, e) =>
-            {
-                // Forward the mouse wheel event to our image's scale transform
-                double zoomChange = e.Delta > 0 ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP;
-                double newZoom = _currentZoom + zoomChange;
-                
-                // Enforce min/max zoom limits
-                newZoom = Math.Max(MIN_ZOOM, Math.Min(MAX_ZOOM, newZoom));
-                
-                // Only update if the zoom actually changed
-                if (Math.Abs(_currentZoom - newZoom) > 0.001)
-                {
-                    _currentZoom = newZoom;
-                    
-                    // Apply the new zoom factor to the ScaleTransform
-                    imageScale.ScaleX = _currentZoom;
-                    imageScale.ScaleY = _currentZoom;
-                    
-                    e.Handled = true;
-                }
-            };
+            _fullscreenWindow.MouseWheel += HandleMouseWheel;
             
             // Close the fullscreen window when this window closes
             this.Closed += (s, e) => 
@@ -402,6 +382,28 @@ namespace PngViewer
             {
                 _isDragging = false;
                 this.ReleaseMouseCapture();
+            }
+        }
+        
+        private void HandleMouseWheel(object sender, WinInput.MouseWheelEventArgs e)
+        {
+            // Calculate new zoom factor based on wheel direction
+            double zoomChange = e.Delta > 0 ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP;
+            double newZoom = _currentZoom + zoomChange;
+            
+            // Enforce min/max zoom limits
+            newZoom = Math.Max(MIN_ZOOM, Math.Min(MAX_ZOOM, newZoom));
+            
+            // Only update if the zoom actually changed
+            if (Math.Abs(_currentZoom - newZoom) > 0.001)
+            {
+                _currentZoom = newZoom;
+                
+                // Apply the new zoom factor to the ScaleTransform
+                imageScale.ScaleX = _currentZoom;
+                imageScale.ScaleY = _currentZoom;
+                
+                e.Handled = true;
             }
         }
         

--- a/PngViewer/TransparentImageWindow.xaml.cs
+++ b/PngViewer/TransparentImageWindow.xaml.cs
@@ -3,8 +3,6 @@ using System.IO;
 using System.Windows;
 using System.Windows.Threading;
 using System.ComponentModel;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 // Use aliases to avoid ambiguity
@@ -34,8 +32,8 @@ namespace PngViewer
         private const double MAX_ZOOM = 10.0;
         private double _currentZoom = 1.0;
         
-        // Fullscreen capture window
-        private Window _captureWindow = null;
+        // Fixed fullscreen window
+        private Window _fullscreenWindow = null;
         
         // Win32 constants for window styles
         private const int GWL_STYLE = -16;
@@ -53,7 +51,7 @@ namespace PngViewer
         private const uint SWP_NOACTIVATE = 0x0010;
         private const uint SWP_SHOWWINDOW = 0x0040;
         private const int HWND_TOPMOST = -1;
-        private const int HWND_BOTTOM = 1;
+        private const int HWND_NOTOPMOST = -2;
         
         [DllImport("user32.dll", SetLastError = true)]
         private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
@@ -112,7 +110,10 @@ namespace PngViewer
             // Make sure it stays on top
             this.Topmost = true;
             
-            // Start loading
+            // First create the fullscreen window
+            CreateFullscreenWindow();
+            
+            // Then start loading the image
             _imageLoader.RunWorkerAsync(imagePath);
         }
 
@@ -128,88 +129,135 @@ namespace PngViewer
             var exStyle = GetWindowLong(_windowHandle, GWL_EXSTYLE);
             SetWindowLong(_windowHandle, GWL_EXSTYLE, exStyle | WS_EX_TOOLWINDOW);
             
-            // Ensure window is visible and topmost
-            SetWindowPos(_windowHandle, (IntPtr)HWND_TOPMOST, 0, 0, 0, 0, 
+            // Ensure window is visible and topmost, but below our fullscreen window
+            SetWindowPos(_windowHandle, (IntPtr)HWND_NOTOPMOST, 0, 0, 0, 0, 
                 SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
-            
-            // Create the fullscreen capture window
-            CreateCaptureWindow();
             
             // Start visibility timer
             _visibilityTimer.Start();
         }
         
-        private void CreateCaptureWindow()
+        private void CreateFullscreenWindow()
         {
-            // Find the screen our window is on
-            var currentScreen = WinForms.Screen.FromHandle(_windowHandle);
+            // Create a truly fullscreen window that covers ALL screens
+            double totalWidth = 0;
+            double totalHeight = 0;
+            double minX = 0;
+            double minY = 0;
             
-            // Create an invisible window that covers the entire screen's working area
-            _captureWindow = new Window
+            // Find the bounding rectangle that encompasses all screens
+            foreach (WinForms.Screen screen in WinForms.Screen.AllScreens)
+            {
+                if (screen.Bounds.Left < minX)
+                    minX = screen.Bounds.Left;
+                if (screen.Bounds.Top < minY)
+                    minY = screen.Bounds.Top;
+                
+                if (screen.Bounds.Right > totalWidth)
+                    totalWidth = screen.Bounds.Right;
+                if (screen.Bounds.Bottom > totalHeight)
+                    totalHeight = screen.Bounds.Bottom;
+            }
+            
+            // Create the window that covers everything
+            _fullscreenWindow = new Window
             {
                 WindowStyle = WindowStyle.None,
                 AllowsTransparency = true,
-                Background = new WinMedia.SolidColorBrush(WinMedia.Color.FromArgb(1, 0, 0, 0)), // Nearly transparent
+                Background = new WinMedia.SolidColorBrush(WinMedia.Color.FromArgb(1, 0, 0, 0)), // Completely transparent
                 Topmost = true,
                 ResizeMode = ResizeMode.NoResize,
                 ShowInTaskbar = false,
-                Title = "PNG Capture Area",
-                Width = currentScreen.WorkingArea.Width,
-                Height = currentScreen.WorkingArea.Height,
-                Left = currentScreen.WorkingArea.Left,
-                Top = currentScreen.WorkingArea.Top
+                Title = "Fullscreen Capture",
+                Width = Math.Abs(totalWidth),
+                Height = Math.Abs(totalHeight),
+                Left = minX,
+                Top = minY
             };
             
-            // Make it not focusable so it doesn't steal focus
-            _captureWindow.Focusable = false;
+            // Disable window interactions
+            _fullscreenWindow.Focusable = false;
+            _fullscreenWindow.IsHitTestVisible = true; // We need this to capture mouse wheel events
             
             // Wire up mouse wheel event to be forwarded to our window
-            _captureWindow.MouseWheel += (s, e) =>
+            _fullscreenWindow.MouseWheel += (s, e) =>
             {
-                // Forward the mouse wheel event to our window
-                Window_MouseWheel(s, e);
-                e.Handled = true;
+                // Forward the mouse wheel event to our image's scale transform
+                double zoomChange = e.Delta > 0 ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP;
+                double newZoom = _currentZoom + zoomChange;
+                
+                // Enforce min/max zoom limits
+                newZoom = Math.Max(MIN_ZOOM, Math.Min(MAX_ZOOM, newZoom));
+                
+                // Only update if the zoom actually changed
+                if (Math.Abs(_currentZoom - newZoom) > 0.001)
+                {
+                    _currentZoom = newZoom;
+                    
+                    // Apply the new zoom factor to the ScaleTransform
+                    imageScale.ScaleX = _currentZoom;
+                    imageScale.ScaleY = _currentZoom;
+                    
+                    e.Handled = true;
+                }
             };
             
-            // Add an event handler to close the capture window when the main window closes
-            _captureWindow.Closed += (s, e) => 
+            // Close the fullscreen window when this window closes
+            this.Closed += (s, e) => 
             {
-                _captureWindow = null;
+                if (_fullscreenWindow != null)
+                {
+                    _fullscreenWindow.Close();
+                    _fullscreenWindow = null;
+                }
             };
             
             // Show the window
-            _captureWindow.Show();
+            _fullscreenWindow.Show();
             
-            // Further customize it with Win32 API calls
-            var hwnd = new WinInterop.WindowInteropHelper(_captureWindow).Handle;
-            
-            // Make it a tool window that doesn't appear in Alt+Tab
+            // Apply window style changes to make it capture events but be otherwise invisible
+            var hwnd = new WinInterop.WindowInteropHelper(_fullscreenWindow).Handle;
             var exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
             SetWindowLong(hwnd, GWL_EXSTYLE, exStyle | WS_EX_TOOLWINDOW | WS_EX_TRANSPARENT | WS_EX_LAYERED);
-            
-            // Set it to be slightly more transparent
             SetLayeredWindowAttributes(hwnd, 0, 1, LWA_ALPHA);
             
-            // Position it behind our PNG window but still above most other windows
-            SetWindowPos(hwnd, (IntPtr)HWND_BOTTOM, 0, 0, 0, 0, 
+            // Make sure it's on top of everything
+            SetWindowPos(hwnd, (IntPtr)HWND_TOPMOST, 0, 0, 0, 0, 
                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
         }
         
         private void TransparentImageWindow_Activated(object sender, EventArgs e)
         {
-            // When window is activated, ensure it remains topmost
+            // Make sure our PNG window is above normal windows
             this.Topmost = true;
+            
+            // But ensure our fullscreen window is above the PNG
+            if (_fullscreenWindow != null)
+            {
+                _fullscreenWindow.Topmost = true;
+                var hwnd = new WinInterop.WindowInteropHelper(_fullscreenWindow).Handle;
+                SetWindowPos(hwnd, (IntPtr)HWND_TOPMOST, 0, 0, 0, 0, 
+                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+            }
         }
         
         private void TransparentImageWindow_Deactivated(object sender, EventArgs e)
         {
-            // Prevent window from losing topmost status when deactivated
+            // Same as in Activated - ensure proper Z-order
             this.Topmost = true;
+            
+            if (_fullscreenWindow != null)
+            {
+                _fullscreenWindow.Topmost = true;
+                var hwnd = new WinInterop.WindowInteropHelper(_fullscreenWindow).Handle;
+                SetWindowPos(hwnd, (IntPtr)HWND_TOPMOST, 0, 0, 0, 0, 
+                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+            }
         }
         
         private void VisibilityTimer_Tick(object sender, EventArgs e)
         {
-            // Safety mechanism to ensure window stays visible
+            // Safety mechanism to ensure windows stay visible in proper Z-order
             if (_windowHandle != IntPtr.Zero && !_disposed)
             {
                 if (!IsWindowVisible(_windowHandle))
@@ -217,12 +265,21 @@ namespace PngViewer
                     // Window became invisible, make it visible again
                     ShowWindow(_windowHandle, SW_SHOW);
                     
-                    // Ensure it's topmost
-                    SetWindowPos(_windowHandle, (IntPtr)HWND_TOPMOST, 0, 0, 0, 0, 
-                        SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
-                    
                     // Update topmost property
                     this.Topmost = true;
+                }
+            }
+            
+            // Also check the fullscreen window
+            if (_fullscreenWindow != null)
+            {
+                var hwnd = new WinInterop.WindowInteropHelper(_fullscreenWindow).Handle;
+                if (!IsWindowVisible(hwnd))
+                {
+                    ShowWindow(hwnd, SW_SHOW);
+                    _fullscreenWindow.Topmost = true;
+                    SetWindowPos(hwnd, (IntPtr)HWND_TOPMOST, 0, 0, 0, 0, 
+                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
                 }
             }
         }
@@ -274,11 +331,19 @@ namespace PngViewer
                 // Ensure window is centered on screen
                 CenterWindowOnScreen();
                 
-                // Make sure it's visible and on top after resizing
+                // Make sure it's visible but still below our fullscreen window
                 if (_windowHandle != IntPtr.Zero)
                 {
-                    SetWindowPos(_windowHandle, (IntPtr)HWND_TOPMOST, 0, 0, 0, 0, 
+                    SetWindowPos(_windowHandle, (IntPtr)HWND_NOTOPMOST, 0, 0, 0, 0, 
                         SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                    
+                    // Make sure fullscreen window is above
+                    if (_fullscreenWindow != null)
+                    {
+                        var hwnd = new WinInterop.WindowInteropHelper(_fullscreenWindow).Handle;
+                        SetWindowPos(hwnd, (IntPtr)HWND_TOPMOST, 0, 0, 0, 0, 
+                            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+                    }
                 }
             }
         }
@@ -302,7 +367,7 @@ namespace PngViewer
             _dragStartPoint = e.GetPosition(this);
             this.CaptureMouse();
             
-            // Ensure it remains topmost
+            // Ensure it remains topmost among normal windows
             this.Topmost = true;
             
             e.Handled = true;
@@ -326,26 +391,8 @@ namespace PngViewer
                 Left = newLeft;
                 Top = newTop;
                 
-                // Ensure the window stays topmost
+                // Ensure the window stays topmost among regular windows
                 this.Topmost = true;
-                
-                // When we drag to a new position, we need to update the capture window
-                UpdateCaptureWindowPosition();
-            }
-        }
-        
-        private void UpdateCaptureWindowPosition()
-        {
-            if (_captureWindow != null)
-            {
-                // Find the screen our window is now on
-                var currentScreen = WinForms.Screen.FromHandle(_windowHandle);
-                
-                // Update the capture window to match the current screen
-                _captureWindow.Width = currentScreen.WorkingArea.Width;
-                _captureWindow.Height = currentScreen.WorkingArea.Height;
-                _captureWindow.Left = currentScreen.WorkingArea.Left;
-                _captureWindow.Top = currentScreen.WorkingArea.Top;
             }
         }
         
@@ -355,28 +402,6 @@ namespace PngViewer
             {
                 _isDragging = false;
                 this.ReleaseMouseCapture();
-            }
-        }
-        
-        private void Window_MouseWheel(object sender, WinInput.MouseWheelEventArgs e)
-        {
-            // Calculate new zoom factor based on wheel direction
-            double zoomChange = e.Delta > 0 ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP;
-            double newZoom = _currentZoom + zoomChange;
-            
-            // Enforce min/max zoom limits
-            newZoom = Math.Max(MIN_ZOOM, Math.Min(MAX_ZOOM, newZoom));
-            
-            // Only update if the zoom actually changed
-            if (Math.Abs(_currentZoom - newZoom) > 0.001)
-            {
-                _currentZoom = newZoom;
-                
-                // Apply the new zoom factor to the ScaleTransform
-                imageScale.ScaleX = _currentZoom;
-                imageScale.ScaleY = _currentZoom;
-                
-                e.Handled = true;
             }
         }
         
@@ -406,19 +431,19 @@ namespace PngViewer
             // Stop the visibility timer
             _visibilityTimer.Stop();
             
-            // Close the capture window
-            CloseCaptureWindow();
+            // Close the fullscreen window
+            CloseFullscreenWindow();
             
             base.OnClosing(e);
             Dispose();
         }
         
-        private void CloseCaptureWindow()
+        private void CloseFullscreenWindow()
         {
-            if (_captureWindow != null)
+            if (_fullscreenWindow != null)
             {
-                _captureWindow.Close();
-                _captureWindow = null;
+                _fullscreenWindow.Close();
+                _fullscreenWindow = null;
             }
         }
         
@@ -438,8 +463,8 @@ namespace PngViewer
                 // Stop the visibility timer
                 _visibilityTimer.Stop();
                 
-                // Close the capture window
-                CloseCaptureWindow();
+                // Close the fullscreen window
+                CloseFullscreenWindow();
                 
                 // Cancel any ongoing operations
                 if (_imageLoader.IsBusy)
@@ -471,13 +496,5 @@ namespace PngViewer
                 image = null;
             }
         }
-    }
-    
-    public class ScreenInfo
-    {
-        public WinForms.Screen Screen { get; set; }
-        public Rect Bounds { get; set; }
-        public Rect WorkingArea { get; set; }
-        public bool IsPrimary { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ A high-performance, memory-efficient PNG viewer application built with C# and WP
   - Save modified images
 - Floating transparent PNG view with:
   - Direct mouse wheel zoom in/out
-  - Smart bounding box modes (standard or fullscreen)
+  - Fullscreen red bounding box that appears when zoomed
   - Multi-monitor support for fullscreen bounding box
+  - Automatic screen detection when moving between monitors
   - Drag to reposition
   - Press 'R' key to reset zoom
-  - Press 'B' key to toggle bounding box
-  - Press 'F' key to switch between standard/fullscreen bounding box modes
+  - Press 'B' key to toggle bounding box visibility
 - Responsive interface that works well with large image collections
 - Live memory usage monitoring
 - Proper resource cleanup
@@ -60,17 +60,17 @@ This application includes several optimizations to minimize memory usage:
 - **Shift + Drag**: Select area for cropping
 - **Escape or Space**: Close the floating transparent viewer
 - **R key**: Reset zoom in the floating transparent viewer
-- **B key**: Toggle the bounding box in the floating transparent viewer
-- **F key**: Switch between standard and fullscreen bounding box modes
+- **B key**: Toggle the fullscreen bounding box visibility
 
-### Bounding Box Modes
+### Fullscreen Bounding Box
 
-The floating transparent PNG viewer supports two bounding box modes:
+When using the floating transparent PNG viewer and zooming in/out, a red border automatically appears around the entire screen. This helps maintain context and orientation when examining image details.
 
-1. **Standard Mode**: Shows a red outline around the original image dimensions
-2. **Fullscreen Mode**: Shows a red outline around the entire screen
-
-When moving the floating PNG between monitors, the fullscreen bounding box will automatically switch to the current monitor, maintaining proper context in multi-monitor setups.
+The fullscreen border:
+- Automatically appears when zooming (not displayed at 1.0x zoom)
+- Automatically follows the PNG when moved between monitors
+- Can be toggled on/off with the 'B' key
+- Works with any monitor setup (single, dual, or multiple)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,9 @@ A high-performance, memory-efficient PNG viewer application built with C# and WP
   - Save modified images
 - Floating transparent PNG view with:
   - Direct mouse wheel zoom in/out
-  - Fullscreen red bounding box that appears when zoomed
-  - Multi-monitor support for fullscreen bounding box
-  - Automatic screen detection when moving between monitors
+  - Smooth scaling transforms for high-quality zoom
   - Drag to reposition
   - Press 'R' key to reset zoom
-  - Press 'B' key to toggle bounding box visibility
 - Responsive interface that works well with large image collections
 - Live memory usage monitoring
 - Proper resource cleanup
@@ -60,17 +57,6 @@ This application includes several optimizations to minimize memory usage:
 - **Shift + Drag**: Select area for cropping
 - **Escape or Space**: Close the floating transparent viewer
 - **R key**: Reset zoom in the floating transparent viewer
-- **B key**: Toggle the fullscreen bounding box visibility
-
-### Fullscreen Bounding Box
-
-When using the floating transparent PNG viewer and zooming in/out, a red border automatically appears around the entire screen. This helps maintain context and orientation when examining image details.
-
-The fullscreen border:
-- Automatically appears when zooming (not displayed at 1.0x zoom)
-- Automatically follows the PNG when moved between monitors
-- Can be toggled on/off with the 'B' key
-- Works with any monitor setup (single, dual, or multiple)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A high-performance, memory-efficient PNG viewer application built with C# and WP
   - 90° rotation (left/right)
   - Precise cropping functionality (Shift+Drag to select area)
   - Save modified images
+- Floating transparent PNG view with:
+  - Direct mouse wheel zoom in/out
+  - Drag to reposition
+  - Press 'R' key to reset zoom
 - Responsive interface that works well with large image collections
 - Live memory usage monitoring
 - Proper resource cleanup
@@ -46,10 +50,12 @@ This application includes several optimizations to minimize memory usage:
 
 ### Keyboard and Mouse Controls
 
-- **Ctrl + Mouse Wheel**: Zoom in/out
+- **Ctrl + Mouse Wheel**: Zoom in/out in the standard viewer
+- **Mouse Wheel**: Zoom in/out in the floating transparent viewer
 - **Drag**: Pan the image when zoomed in
 - **Shift + Drag**: Select area for cropping
-- **Escape**: Cancel crop selection
+- **Escape or Space**: Close the floating transparent viewer
+- **R key**: Reset zoom in the floating transparent viewer
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A high-performance, memory-efficient PNG viewer application built with C# and WP
   - Precise cropping functionality (Shift+Drag to select area)
   - Save modified images
 - Floating transparent PNG view with:
-  - Direct mouse wheel zoom in/out
+  - Direct mouse wheel zoom in/out **from anywhere on screen**
+  - Fullscreen mouse wheel capture for zooming without having to hover over the PNG
   - Smooth scaling transforms for high-quality zoom
   - Drag to reposition
   - Press 'R' key to reset zoom
@@ -52,7 +53,7 @@ This application includes several optimizations to minimize memory usage:
 ### Keyboard and Mouse Controls
 
 - **Ctrl + Mouse Wheel**: Zoom in/out in the standard viewer
-- **Mouse Wheel**: Zoom in/out in the floating transparent viewer
+- **Mouse Wheel** (anywhere on screen): Zoom in/out in the floating transparent viewer
 - **Drag**: Pan the image when zoomed in
 - **Shift + Drag**: Select area for cropping
 - **Escape or Space**: Close the floating transparent viewer

--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ A high-performance, memory-efficient PNG viewer application built with C# and WP
   - Save modified images
 - Floating transparent PNG view with:
   - Direct mouse wheel zoom in/out
-  - Red bounding box outline when zoomed
+  - Smart bounding box modes (standard or fullscreen)
+  - Multi-monitor support for fullscreen bounding box
   - Drag to reposition
   - Press 'R' key to reset zoom
   - Press 'B' key to toggle bounding box
+  - Press 'F' key to switch between standard/fullscreen bounding box modes
 - Responsive interface that works well with large image collections
 - Live memory usage monitoring
 - Proper resource cleanup
@@ -58,7 +60,17 @@ This application includes several optimizations to minimize memory usage:
 - **Shift + Drag**: Select area for cropping
 - **Escape or Space**: Close the floating transparent viewer
 - **R key**: Reset zoom in the floating transparent viewer
-- **B key**: Toggle the red bounding box in the floating transparent viewer
+- **B key**: Toggle the bounding box in the floating transparent viewer
+- **F key**: Switch between standard and fullscreen bounding box modes
+
+### Bounding Box Modes
+
+The floating transparent PNG viewer supports two bounding box modes:
+
+1. **Standard Mode**: Shows a red outline around the original image dimensions
+2. **Fullscreen Mode**: Shows a red outline around the entire screen
+
+When moving the floating PNG between monitors, the fullscreen bounding box will automatically switch to the current monitor, maintaining proper context in multi-monitor setups.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ A high-performance, memory-efficient PNG viewer application built with C# and WP
   - Save modified images
 - Floating transparent PNG view with:
   - Direct mouse wheel zoom in/out
+  - Red bounding box outline when zoomed
   - Drag to reposition
   - Press 'R' key to reset zoom
+  - Press 'B' key to toggle bounding box
 - Responsive interface that works well with large image collections
 - Live memory usage monitoring
 - Proper resource cleanup
@@ -56,6 +58,7 @@ This application includes several optimizations to minimize memory usage:
 - **Shift + Drag**: Select area for cropping
 - **Escape or Space**: Close the floating transparent viewer
 - **R key**: Reset zoom in the floating transparent viewer
+- **B key**: Toggle the red bounding box in the floating transparent viewer
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ A high-performance, memory-efficient PNG viewer application built with C# and WP
   - Precise cropping functionality (Shift+Drag to select area)
   - Save modified images
 - Floating transparent PNG view with:
-  - Direct mouse wheel zoom in/out **from anywhere on screen**
-  - Fullscreen mouse wheel capture for zooming without having to hover over the PNG
-  - Smooth scaling transforms for high-quality zoom
-  - Drag to reposition
+  - Mouse wheel zoom from **anywhere on screen**
+  - Fixed fullscreen transparent input capture
+  - Freely movable PNG with precise positioning
   - Press 'R' key to reset zoom
 - Responsive interface that works well with large image collections
 - Live memory usage monitoring
@@ -54,7 +53,7 @@ This application includes several optimizations to minimize memory usage:
 
 - **Ctrl + Mouse Wheel**: Zoom in/out in the standard viewer
 - **Mouse Wheel** (anywhere on screen): Zoom in/out in the floating transparent viewer
-- **Drag**: Pan the image when zoomed in
+- **Drag**: Pan the image when zoomed in or reposition the floating PNG
 - **Shift + Drag**: Select area for cropping
 - **Escape or Space**: Close the floating transparent viewer
 - **R key**: Reset zoom in the floating transparent viewer


### PR DESCRIPTION
## Feature: Mouse Wheel Zoom for Floating Transparent PNGs with Fullscreen Input Capture

This PR adds the ability to zoom in and out of a floating transparent PNG window using the mouse wheel from anywhere on screen, without resizing the window itself. The PNG window can be moved freely while zooming operations can be performed from anywhere on screen.

### Key Implementation Details:
- Added a ScaleTransform to the PNG image element to smoothly handle zoom
- Set RenderTransformOrigin to 0.5,0.5 so the image scales from its center
- Created a completely transparent fullscreen window that covers ALL monitors
- Made the fullscreen window fixed and unmovable to capture mouse wheel input anywhere
- Implemented proper Z-order management to ensure PNG stays above normal windows but below the input capture layer
- Added 'R' key shortcut to reset zoom to 1.0
- Maintained the window dimensions while scaling only the content

### User Experience Improvements:
- Users can now zoom the PNG by scrolling the mouse wheel from ANYWHERE on screen
- No need to hover directly over the PNG to zoom it
- The PNG window remains freely movable to allow precise positioning
- The zoom operation is smooth and intuitive with high-quality scaling
- The fullscreen capture layer is completely invisible and doesn't interfere with any other applications
- Supports multi-monitor setups by spanning across all screens
- Reset functionality via 'R' key for easy return to default view

### Technical Notes:
- Implemented a layered window architecture:
  1. Top layer: Invisible fullscreen window that captures mouse wheel events
  2. Middle layer: The floating transparent PNG window
  3. Bottom layer: All other applications
- Used Win32 API flags to ensure proper event handling without visual interference
- Automatic Z-order maintenance through window activation hooks
- Proper cleanup with IDisposable implementation to free all resources
- Updated README with new feature documentation

This feature makes transparent PNG viewing much more convenient for design work, allowing for seamless zooming from anywhere while keeping the PNG fully movable for precise positioning.